### PR TITLE
feat: addresses post, because of body and large args

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The response data follows the [`jsend`](https://labs.omniti.com/labs/jsend) stan
 
 ### Get multiple orbitDB root store addresses for given identities
 
-`GET /odbAddresses`
+`Post /odbAddresses`
 
 Returns multiple root store addresses from multiple identities. If some identities are present but not all, the response will only contain the ones that do have root store addresses associated with them.
 
@@ -168,4 +168,3 @@ The response data follows the [`jsend`](https://labs.omniti.com/labs/jsend) stan
   }
 }
 ```
-

--- a/serverless.yml
+++ b/serverless.yml
@@ -56,12 +56,12 @@ functions:
                 id: true
 
   root_store_addresses_get:
-    handler: src/api_handler.root_store_addresses_get
+    handler: src/api_handler.root_store_addresses_post
     timeout: 30
     events:
       - http:
          path: odbAddresses
-         method: get
+         method: post
          cors: true
 
   link_post:
@@ -72,4 +72,3 @@ functions:
          path: link
          method: post
          cors: true
-

--- a/src/api/__tests__/root_store_addresses_post.test.js
+++ b/src/api/__tests__/root_store_addresses_post.test.js
@@ -1,10 +1,10 @@
-const RootStoreAddressesGet = require('../root_store_addresses_get')
+const RootStoreAddressesPost = require('../root_store_addresses_post')
 
 const formatEvent = obj => {
   return { body: JSON.stringify(obj) }
 }
 
-describe('RootStoreAddressesGet', () => {
+describe('RootStoreAddressesPost', () => {
   let sut
   let addressMgrMock
   let linkMgrMock
@@ -42,7 +42,7 @@ describe('RootStoreAddressesGet', () => {
         }
       })
     }
-    sut = new RootStoreAddressesGet(addressMgrMock, linkMgrMock)
+    sut = new RootStoreAddressesPost(addressMgrMock, linkMgrMock)
   })
 
   afterEach(() => {

--- a/src/api/root_store_addresses_post.js
+++ b/src/api/root_store_addresses_post.js
@@ -1,4 +1,4 @@
-class RootStoreAddressesGetHandler {
+class RootStoreAddressesPostHandler {
   constructor(addressMgr, linkMgr) {
     this.addressMgr = addressMgr
     this.linkMgr = linkMgr
@@ -62,4 +62,4 @@ class RootStoreAddressesGetHandler {
     return did
   }
 }
-module.exports = RootStoreAddressesGetHandler
+module.exports = RootStoreAddressesPostHandler

--- a/src/api_handler.js
+++ b/src/api_handler.js
@@ -9,7 +9,7 @@ const SigMgr = require('./lib/sigMgr')
 
 const RootStoreAddressPostHanlder = require('./api/root_store_address_post')
 const RootStoreAddressGetHanlder = require('./api/root_store_address_get')
-const RootStoreAddressesGetHanlder = require('./api/root_store_addresses_get')
+const RootStoreAddressesPostHanlder = require('./api/root_store_addresses_post')
 const LinkPostHandler = require('./api/link_post')
 
 let uPortMgr = new UportMgr()
@@ -87,7 +87,7 @@ module.exports.root_store_address_get = (event, context, callback) => {
   preHandler(rsAddressGetHanlder, event, context, callback)
 }
 
-let rsAddressesGetHanlder = new RootStoreAddressesGetHanlder(addressMgr, linkMgr)
+let rsAddressesGetHanlder = new RootStoreAddressesPostHanlder(addressMgr, linkMgr)
 module.exports.root_store_addresses_get = (event, context, callback) => {
   preHandler(rsAddressesGetHanlder, event, context, callback)
 }


### PR DESCRIPTION
Many req libs don't support body for get requests, seems somewhat standard. And then if passing in params the list maybe too large. Seems like suggested change is just to change it to a post request. I'm doing the same in the pinning server as well for profile list request. 