### PR TITLE
add hex string validator

### DIFF
--- a/src/api/__tests__/root_store_address_get.test.js
+++ b/src/api/__tests__/root_store_address_get.test.js
@@ -71,6 +71,19 @@ describe('RootStoreAddressGet', () => {
     })
   })
 
+  test('adress contains uppercase', done => {
+    let invalidAddress = '0xBF7571b900839fa871e6f6efbbfd238eaa502735'
+    linkMgrMock.get.mockReturnValue({ did: did })
+    addressMgrMock.get.mockReturnValue({ root_store_address: rsAddress })
+
+    sut.handle({ pathParameters: { id: invalidAddress } }, {}, (err, res) => {
+      expect(err).not.toBeNull()
+      expect(err.code).toEqual(403)
+      expect(err.message).toEqual('Error: must be a lowercase hex string')
+      done()
+    })
+  })
+
   test('happy path (address)', done => {
     linkMgrMock.get.mockReturnValue({ did: did })
     addressMgrMock.get.mockReturnValue({ root_store_address: rsAddress })

--- a/src/api/__tests__/root_store_addresses_post.test.js
+++ b/src/api/__tests__/root_store_addresses_post.test.js
@@ -208,4 +208,22 @@ describe('RootStoreAddressesPost', () => {
       done()
     })
   })
+
+  test('happy path (mixed dids, addresses, upper-case addresses)', done => {
+    sut.handle(formatEvent({ identities: [address1, '0xBF7571b900839fa871e6f6efbbfd238eaa502736', did3, did4] }), {}, (err, res) => {
+      expect(linkMgrMock.get).toHaveBeenCalledWith(address1)
+      expect(linkMgrMock.get).toHaveBeenCalledTimes(1)
+      expect(addressMgrMock.get).toHaveBeenCalledWith(did1)
+      expect(addressMgrMock.get).toHaveBeenCalledWith(did3)
+      expect(addressMgrMock.get).toHaveBeenCalledWith(did4)
+      expect(addressMgrMock.get).toHaveBeenCalledTimes(3)
+      expect(err).toBeNull()
+      const expectedRes = { rootStoreAddresses: {} }
+      expectedRes.rootStoreAddresses[address1] = rsAddress1
+      expectedRes.rootStoreAddresses[did3] = rsAddress3
+      expectedRes.rootStoreAddresses[did4] = rsAddress4
+      expect(res).toEqual(expectedRes)
+      done()
+    })
+  })
 })

--- a/src/api/root_store_address_get.js
+++ b/src/api/root_store_address_get.js
@@ -1,3 +1,5 @@
+const { hexString } = require('../lib/validator')
+
 class RootStoreAddressGetHandler {
   constructor(addressMgr, linkMgr) {
     this.addressMgr = addressMgr
@@ -14,6 +16,10 @@ class RootStoreAddressGetHandler {
     // Check if id is an address or a did
     let did
     if (id.startsWith('0x')) {
+      const { error } = hexString.validate(id)
+      if (error) {
+        cb({ code: 403, message: error.toString() })
+      }
       const didRow = await this.linkMgr.get(id)
       if (!didRow) {
         cb({ code: 404, message: 'address not linked' })

--- a/src/api/root_store_addresses_post.js
+++ b/src/api/root_store_addresses_post.js
@@ -1,3 +1,5 @@
+const { hexString } = require('../lib/validator')
+
 class RootStoreAddressesPostHandler {
   constructor(addressMgr, linkMgr) {
     this.addressMgr = addressMgr
@@ -49,6 +51,10 @@ class RootStoreAddressesPostHandler {
     // Check if id is an address or a did
     let did
     if (id.startsWith('0x')) {
+      const { error } = hexString.validate(id)
+      if (error) {
+        return null
+      }
       const didRow = await this.linkMgr.get(id)
       if (!didRow) {
         return null

--- a/src/lib/validator.js
+++ b/src/lib/validator.js
@@ -1,0 +1,17 @@
+class RegexValidator {
+	constructor(regex, error) {
+		this.regex = regex
+		this.error = error
+	}
+
+	validate(input) {
+		if (this.regex.test(input)) {
+			return { error: null, value: input }
+		}
+		return { error: this.error, value: null }
+	}
+}
+
+module.exports = {
+	hexString: new RegexValidator(/^0x[0-9a-f]+$/, new Error('must be a lowercase hex string'))
+}


### PR DESCRIPTION
Looked into using serverless request validation, but it can't be applied to path parameters (limitation of AWS API gateways). To keep the validation consistent, this is instead done through a validation class.