### PR TITLE
remove explicit setting of AWS credentials for s3 client

### DIFF
--- a/src/api_handler.js
+++ b/src/api_handler.js
@@ -71,8 +71,6 @@ const pick = (obj, keys) => {
 const configKeys = [
   'PG_URL',
   'IPFS_PATH',
-  'AWS_ACCESS_KEY_ID',
-  'AWS_SECRET_ACCESS_KEY',
   'AWS_BUCKET_NAME',
   'AWS_S3_ENDPOINT',
   'AWS_S3_ADDRESSING_STYLE',

--- a/src/lib/uPortMgr.js
+++ b/src/lib/uPortMgr.js
@@ -18,8 +18,6 @@ class UportMgr {
     const config = {
       ipfsPath: secrets.IPFS_PATH,
       bucket: secrets.AWS_BUCKET_NAME,
-      accessKeyId: secrets.AWS_ACCESS_KEY_ID,
-      secretAccessKey: secrets.AWS_SECRET_ACCESS_KEY,
       endpoint: secrets.AWS_S3_ENDPOINT,
       s3ForcePathStyle: secrets.AWS_S3_ADDRESSING_STYLE === 'path',
       signatureVersion: secrets.AWS_S3_SIGNATURE_VERSION,


### PR DESCRIPTION
Bug manifests as a 401 on `POST /odbAddress` with a response of `{"status":"error","message":"Invalid JWT"}` (for example, when creating a new profile)

To test, try with each of this commit, and v1.1.4:

- deploy to DEV
- run the example server against dev
- create a new metamask account
- open box on example server
