### PR TITLE
fix(link): don't verify EOA type signature for erc1271 contracts

### DIFF
--- a/src/api/link_post.js
+++ b/src/api/link_post.js
@@ -87,7 +87,7 @@ class LinkPostHandler {
     } = await handlers[version](body, cb)
 
     // Get address from signature + msg
-    const address = await this.sigMgr.verify(msg, sig)
+    const address = type === ACCOUNT_TYPES.erc1271 ? contractAddress : await this.sigMgr.verify(msg, sig)
     const consent = JSON.stringify({ msg, sig })
 
     await this.linkMgr.store(address, did, consent, type, chainId, contractAddress, timestamp)


### PR DESCRIPTION
This PR fixes a bug where we where trying to verify an EOA signature even if the signature being verified is made from an erc1271 contract. This is a problem for all contract wallets.

Side note: We should really be using the [3id-blockchain-utils](https://github.com/3box/js-3id-blockchain-utils) library here for link validation. This should make this much more stable and remove code duplication.